### PR TITLE
Register the default socket factory

### DIFF
--- a/lib/couchbase_lite/replicator_socket_factory.rb
+++ b/lib/couchbase_lite/replicator_socket_factory.rb
@@ -76,6 +76,10 @@ module CouchbaseLite
       end
     end
 
+    def make_default
+      FFI.c4socket_registerFactory(@c4_socket_factory)
+    end
+
     private
 
     def make_factory
@@ -90,4 +94,7 @@ module CouchbaseLite
       factory
     end
   end
+
+  DEFAULT_SOCKET_FACTORY = ReplicatorSocketFactory.new
+  DEFAULT_SOCKET_FACTORY.make_default
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,11 @@ require 'bundler/setup'
 
 $COUCHBASE_LITE_DEBUG = true if ENV['COUCHBASE_LITE_DEBUG'] == '1'
 
+# It is important to load eventmachine before couchbase_lite or Ruby will crash on Linux
+# The reason is that eventmachine links against libstdc++, while libCoreLite needs libc++.
+# Experimentally, I’ve found that loading libc++ later seems to work around the crash.
+# See https://github.com/temochka/embug-1203 for more details
+require 'eventmachine'
 require 'couchbase_lite'
 require 'couchbase_lite/rspec/contexts'
 require 'couchbase_lite/rspec/matchers'


### PR DESCRIPTION
Looks like Couchbase Lite Core 2.1 requires global factory registration. I’ll abide :)