### PR TITLE
Improved conflict resolution and monitoring

### DIFF
--- a/lib/couchbase_lite.rb
+++ b/lib/couchbase_lite.rb
@@ -93,6 +93,7 @@ end
 require 'couchbase_lite/blob_storage'
 require 'couchbase_lite/database'
 require 'couchbase_lite/document'
+require 'couchbase_lite/document_enumerator'
 require 'couchbase_lite/ffi'
 require 'couchbase_lite/fleece'
 require 'couchbase_lite/live_result'

--- a/lib/couchbase_lite/database.rb
+++ b/lib/couchbase_lite/database.rb
@@ -129,6 +129,18 @@ module CouchbaseLite
       end
     end
 
+    def conflicts(since = 0)
+      c4_doc_enumerator = null_err do |e|
+        FFI.c4db_enumerateChanges(c4_database,
+                                  since,
+                                  FFI::C4EnumeratorOptions.make(only_conflicts: true, bodies: true),
+                                  e)
+      end
+
+      enumerator = DocumentEnumerator.new(FFI::C4DocEnumerator.auto(c4_doc_enumerator))
+      enumerator.lazy.map { |doc| get_conflicts(doc) }
+    end
+
     def get_conflicts(document)
       return [] unless document.conflicted?
 

--- a/lib/couchbase_lite/database.rb
+++ b/lib/couchbase_lite/database.rb
@@ -129,16 +129,12 @@ module CouchbaseLite
       end
     end
 
-    def conflicts(since = 0)
-      c4_doc_enumerator = null_err do |e|
-        FFI.c4db_enumerateChanges(c4_database,
-                                  since,
-                                  FFI::C4EnumeratorOptions.make(only_conflicts: true, bodies: true),
-                                  e)
-      end
+    def documents(**options)
+      DocumentEnumerator.new(self, options)
+    end
 
-      enumerator = DocumentEnumerator.new(FFI::C4DocEnumerator.auto(c4_doc_enumerator))
-      enumerator.lazy.map { |doc| get_conflicts(doc) }
+    def conflicts(**options)
+      documents(**options, only_conflicts: true, bodies: true).lazy.map { |doc| get_conflicts(doc) }
     end
 
     def get_conflicts(document)

--- a/lib/couchbase_lite/database.rb
+++ b/lib/couchbase_lite/database.rb
@@ -129,8 +129,8 @@ module CouchbaseLite
       end
     end
 
-    def documents(**options)
-      DocumentEnumerator.new(self, options)
+    def documents(**options, &block)
+      DocumentEnumerator.new(self, options, &block)
     end
 
     def conflicts(**options)

--- a/lib/couchbase_lite/document_enumerator.rb
+++ b/lib/couchbase_lite/document_enumerator.rb
@@ -1,0 +1,34 @@
+module CouchbaseLite
+  class DocumentEnumerator
+    include Enumerable
+    include ErrorHandling
+
+    def initialize(c4_doc_enumerator)
+      @enumerator = make_enumerator(c4_doc_enumerator)
+    end
+
+    def next
+      @enumerator.next
+    end
+
+    def each(&block)
+      @enumerator.each(&block)
+    end
+
+    private
+
+    def make_enumerator(c4_doc_enumerator)
+      ::Enumerator.new do |docs|
+        error = FFI::C4Error.new
+
+        while FFI.c4enum_next(c4_doc_enumerator, error)
+          c4_doc = null_err do |e|
+            FFI.c4enum_getDocument(c4_doc_enumerator, e)
+          end
+
+          docs << Document.new(c4_doc)
+        end
+      end
+    end
+  end
+end

--- a/lib/couchbase_lite/document_enumerator.rb
+++ b/lib/couchbase_lite/document_enumerator.rb
@@ -3,8 +3,15 @@ module CouchbaseLite
     include Enumerable
     include ErrorHandling
 
-    def initialize(c4_doc_enumerator)
-      @enumerator = make_enumerator(c4_doc_enumerator)
+    def initialize(database, since: 0, **options)
+      c4_doc_enumerator = null_err do |e|
+        FFI.c4db_enumerateChanges(database.c4_database,
+                                  since,
+                                  FFI::C4EnumeratorOptions.make(options),
+                                  e)
+      end
+
+      @enumerator = make_enumerator(FFI::C4DocEnumerator.auto(c4_doc_enumerator))
     end
 
     def next
@@ -26,7 +33,9 @@ module CouchbaseLite
             FFI.c4enum_getDocument(c4_doc_enumerator, e)
           end
 
-          docs << Document.new(c4_doc)
+          doc = Document.new(c4_doc)
+
+          docs << doc
         end
       end
     end

--- a/lib/couchbase_lite/ffi.rb
+++ b/lib/couchbase_lite/ffi.rb
@@ -837,6 +837,115 @@ module CouchbaseLite
 
     attach_function :c4db_encodeJSON, [:pointer, C4Slice.by_value, C4Error.ptr], C4Slice.by_value
 
+    # /** A database-observer reference. */
+    # typedef struct c4DatabaseObserver C4DatabaseObserver;
+    class C4DatabaseObserver < ::FFI::ManagedStruct
+      layout :_unused, :uint8 # opaque
+
+      def self.release(ptr)
+        FFI.c4dbobs_free(ptr)
+      end
+
+      def self.create(c4_database, callback)
+        FFI.c4dbobs_create(c4_database, callback, nil)
+      end
+
+      def self.sequence_callback(async, buffer_size: 500, &block)
+        raise ArgumentError, 'Please provide a callback to receive the updated sequence' unless block_given?
+
+        buffer = ::FFI::MemoryPointer.new(C4DatabaseChange, buffer_size)
+        external = ::FFI::MemoryPointer.new(:bool)
+
+        ->(c4_database_observer, _context) do
+          async.call do
+            begin
+              loop do
+                num_changes = FFI.c4dbobs_getChanges(c4_database_observer, buffer, buffer_size, external)
+                break if num_changes.zero?
+
+                last_change = C4DatabaseChange.new(buffer + (num_changes - 1) * C4DatabaseChange.size)
+
+                block.call(last_change[:sequence], num_changes)
+
+                FFI.c4dbobs_releaseChanges(buffer, num_changes)
+                break if num_changes < buffer_size
+              end
+            rescue => e
+              CouchbaseLite.logger.error e
+            end
+          end
+        end
+      end
+    end
+
+    # typedef struct {
+    #     C4String docID;
+    #     C4String revID;
+    #     C4SequenceNumber sequence;
+    #     uint32_t bodySize;
+    # } C4DatabaseChange;
+    class C4DatabaseChange < ::FFI::Struct
+      layout :docID, C4String,
+             :revID, C4String,
+             :sequence, :uint64,
+             :bodySize, :uint32
+    end
+
+    # /** Callback invoked by a database observer.
+    #     @param observer  The observer that initiated the callback.
+    #     @param context  user-defined parameter given when registering the callback. */
+    # typedef void (*C4DatabaseObserverCallback)(C4DatabaseObserver* observer C4NONNULL,
+    #                                            void *context);
+    callback :database_observer_callback, [C4DatabaseObserver.ptr, :pointer], :void
+
+    # /** Creates a new database observer, with a callback that will be invoked after the database
+    #     changes. The callback will be called _once_, after the first change. After that it won't
+    #     be called again until all of the changes have been read by calling `c4dbobs_getChanges`.
+    #     @param database  The database to observer.
+    #     @param callback  The function to call after the database changes.
+    #     @param context  An arbitrary value that will be passed to the callback.
+    #     @return  The new observer reference. */
+    # C4DatabaseObserver* c4dbobs_create(C4Database* database C4NONNULL,
+    #                                    C4DatabaseObserverCallback callback C4NONNULL,
+    #                                    void *context) C4API;
+    attach_function :c4dbobs_create, [:pointer, :database_observer_callback, :pointer], C4DatabaseObserver.ptr
+
+    # /** Stops an observer and frees the resources it's using.
+    #     It is safe to pass NULL to this call. */
+    # void c4dbobs_free(C4DatabaseObserver*) C4API;
+    attach_function :c4dbobs_free, [C4DatabaseObserver.ptr], :void
+
+    # /** Identifies which documents have changed since the last time this function was called, or
+    #     since the observer was created. This function effectively "reads" changes from a stream,
+    #     in whatever quantity the caller desires. Once all of the changes have been read, the
+    #     observer is reset and ready to notify again.
+    #
+    #     IMPORTANT: After calling this function, you must call `c4dbobs_releaseChanges` to release
+    #     memory that's being referenced by the `C4DatabaseChange`s.
+    #
+    #     @param observer  The observer.
+    #     @param outChanges  A caller-provided buffer of structs into which changes will be
+    #                         written.
+    #     @param maxChanges  The maximum number of changes to return, i.e. the size of the caller's
+    #                         outChanges buffer.
+    #     @param outExternal  Will be set to true if the changes were made by a different C4Database.
+    #     @return  The number of changes written to `outChanges`. If this is less than `maxChanges`,
+    #                         the end has been reached and the observer is reset. */
+    # uint32_t c4dbobs_getChanges(C4DatabaseObserver *observer C4NONNULL,
+    #                             C4DatabaseChange outChanges[] C4NONNULL,
+    #                             uint32_t maxChanges,
+    #                             bool *outExternal C4NONNULL) C4API;
+    attach_function :c4dbobs_getChanges, [C4DatabaseObserver.ptr, :pointer, :uint32, :pointer], :uint32
+
+    # /** Releases the memory used by the C4DatabaseChange structs (to hold the docID and revID
+    #     strings.) This must be called after `c4dbobs_getChanges().
+    #     @param changes  The same array of changes that was passed to `c4dbobs_getChanges`.
+    #     @param numChanges  The number of changes returned by `c4dbobs_getChanges`, i.e. the number
+    #                         of valid items in `changes`. */
+    # void c4dbobs_releaseChanges(C4DatabaseChange changes[],
+    #                             uint32_t numChanges) C4API;
+    attach_function :c4dbobs_releaseChanges, [:pointer, :uint32], :void
+
     attach_function :c4doc_bodyAsJSON, [C4Document.ptr, :bool, C4Error.ptr], C4SliceResult.by_value
 
     attach_function :c4doc_put, [:pointer, C4DocPutRequest.ptr, :pointer, C4Error.ptr], C4Document.ptr

--- a/lib/couchbase_lite/live_result.rb
+++ b/lib/couchbase_lite/live_result.rb
@@ -14,7 +14,7 @@ module CouchbaseLite
       database.delete_observer(self)
     end
 
-    def update(event)
+    def update(event, *_args)
       return unless event == :commit
 
       refreshed = @result.refresh

--- a/lib/couchbase_lite/rspec/contexts.rb
+++ b/lib/couchbase_lite/rspec/contexts.rb
@@ -57,4 +57,6 @@ RSpec.shared_context 'revision conflicts' do |db_name = 'db'|
            history: ['1-0b265579fcb1b06526a7649efae41c8812f4200d'],
            remote_db_id: 1)
   end
+
+  let(:conflicted_document) { db.get('1') }
 end

--- a/lib/couchbase_lite/rspec/contexts.rb
+++ b/lib/couchbase_lite/rspec/contexts.rb
@@ -44,3 +44,17 @@ RSpec.shared_context 'simple dataset' do |db_name = 'db', size = 20|
     records.each_with_index { |r, i| send(db_name).insert(i.to_s, r) }
   end
 end
+
+RSpec.shared_context 'revision conflicts' do |db_name = 'db'|
+  before do
+    db = public_send(db_name)
+
+    db.put('1', { foo: 'bar' })
+    db.put('1',
+           { foo: 'buz' },
+           existing_revision: true,
+           allow_conflict: true,
+           history: ['1-0b265579fcb1b06526a7649efae41c8812f4200d'],
+           remote_db_id: 1)
+  end
+end

--- a/lib/couchbase_lite/rspec/matchers.rb
+++ b/lib/couchbase_lite/rspec/matchers.rb
@@ -49,3 +49,24 @@ RSpec::Matchers.define :run_until do |_|
     @always = block
   end
 end
+
+RSpec::Matchers.define :have_side_effect do |_|
+  match do |block|
+    block.call
+    loop do
+      break if block_arg.call || timeout?
+      sleep 0.01
+    end
+    true
+  end
+
+  supports_block_expectations
+
+  def timeout?
+    @timeout && Time.now.to_i >= @timeout
+  end
+
+  chain :with_timeout do |timeout|
+    @timeout = Time.now.to_i + timeout
+  end
+end

--- a/spec/couchbase_lite/database_spec.rb
+++ b/spec/couchbase_lite/database_spec.rb
@@ -159,6 +159,20 @@ RSpec.describe CouchbaseLite::Database do
     end
   end
 
+  describe '#conflicts' do
+    subject(:conflicts) { db.conflicts.to_a }
+
+    context 'when there are no conflicts' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when there is one conflict' do
+      include_context 'revision conflicts'
+
+      specify { expect(conflicts.count).to eq 1 }
+    end
+  end
+
   describe '#query' do
     subject(:query) { db.query(%w(foo), what: [%w(. foo)]) }
 

--- a/spec/couchbase_lite/database_spec.rb
+++ b/spec/couchbase_lite/database_spec.rb
@@ -159,6 +159,20 @@ RSpec.describe CouchbaseLite::Database do
     end
   end
 
+  describe '#documents' do
+    include_context 'simple dataset', 'db', 42
+
+    subject(:documents) { db.documents }
+
+    before do
+      db.update('0', body)
+    end
+
+    it { is_expected.to be_a(CouchbaseLite::DocumentEnumerator) }
+    specify { expect(documents.count).to eq 42 }
+    specify { expect(documents.map(&:id)).to eq [*1...42, 0].map(&:to_s) }
+  end
+
   describe '#conflicts' do
     subject(:conflicts) { db.conflicts.to_a }
 

--- a/spec/couchbase_lite/live_result_spec.rb
+++ b/spec/couchbase_lite/live_result_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe CouchbaseLite::LiveResult do
         original = live.result
         expect(original).to be_a(result.class)
         expect(original.first).to eq('number' => 0)
-        db.update('0', number: 42)
-        sleep 0.1
-        expect(live.result).to_not eq(original)
+        expect { db.update('0', number: 42) }.to have_side_effect { live.result != original }.with_timeout(5)
         expect(live.result.first).to eq('number' => 1)
       end
     end
@@ -28,10 +26,10 @@ RSpec.describe CouchbaseLite::LiveResult do
       end
 
       it 'runs callback on every commit' do
-        db.delete('0')
-        sleep 0.1
-        db.delete('1')
-        sleep 0.1
+        2.times do |i|
+          original = live.result
+          expect { db.delete(i.to_s) }.to have_side_effect { live.result != original }.with_timeout(5)
+        end
         expect(snapshots).to eq [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
       end
     end

--- a/spec/couchbase_lite/live_result_spec.rb
+++ b/spec/couchbase_lite/live_result_spec.rb
@@ -1,37 +1,51 @@
 require 'spec_helper'
 
 RSpec.describe CouchbaseLite::LiveResult do
-  include_context 'CBLite db test'
-  include_context 'simple dataset'
+  shared_examples_for 'live result' do
+    include_context 'CBLite db test'
+    include_context 'simple dataset'
 
-  let(:query) { n1ql('SELECT number ORDER BY number LIMIT 3') }
+    let(:limit) { 3 }
 
-  context 'without callback' do
-    subject(:live) { query.run.live }
+    context 'without callback' do
+      subject(:live) { result.live }
 
-    it 'auto-refreshes once the change occurs' do
-      original = live.result
-      expect(original).to be_a(CouchbaseLite::QueryResult)
-      expect(original.first).to eq('number' => 0)
-      db.update('0', number: -1)
-      sleep 0.1
-      expect(live.result).to_not eq(original)
-      expect(live.result.first).to eq('number' => -1)
+      it 'auto-refreshes once the change occurs' do
+        original = live.result
+        expect(original).to be_a(result.class)
+        expect(original.first).to eq('number' => 0)
+        db.update('0', number: 42)
+        sleep 0.1
+        expect(live.result).to_not eq(original)
+        expect(live.result.first).to eq('number' => 1)
+      end
+    end
+
+    context 'with callback' do
+      let(:snapshots) { [] }
+      subject!(:live) do
+        result.live { |r| snapshots << r.map { |row| row['number'] }.take(limit) }
+      end
+
+      it 'runs callback on every commit' do
+        db.delete('0')
+        sleep 0.1
+        db.delete('1')
+        sleep 0.1
+        expect(snapshots).to eq [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
+      end
     end
   end
 
-  context 'with callback' do
-    let(:snapshots) { [] }
-    subject!(:live) do
-      query.run.live { |r| snapshots << r.map { |row| row['number'] } }
-    end
+  context 'using with a query' do
+    let(:result) { n1ql('SELECT number ORDER BY number LIMIT $l').run(l: limit) }
 
-    it 'runs callback on every commit' do
-      db.delete('0')
-      sleep 0.1
-      db.delete('1')
-      sleep 0.1
-      expect(snapshots).to eq [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
-    end
+    it_behaves_like 'live result'
+  end
+
+  context 'using with an enumerator' do
+    let(:result) { db.documents(bodies: true) { |doc| { 'number' => doc.body[:number] } } }
+
+    it_behaves_like 'live result'
   end
 end

--- a/spec/couchbase_lite/live_result_spec.rb
+++ b/spec/couchbase_lite/live_result_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe CouchbaseLite::LiveResult do
     subject(:live) { query.run.live }
 
     it 'auto-refreshes once the change occurs' do
-      expect(live.result).to be_a(CouchbaseLite::QueryResult)
-      expect(live.result.first).to eq('number' => 0)
+      original = live.result
+      expect(original).to be_a(CouchbaseLite::QueryResult)
+      expect(original.first).to eq('number' => 0)
       db.update('0', number: -1)
-      expect(live.result)
+      sleep 0.1
+      expect(live.result).to_not eq(original)
       expect(live.result.first).to eq('number' => -1)
     end
   end
@@ -26,7 +28,9 @@ RSpec.describe CouchbaseLite::LiveResult do
 
     it 'runs callback on every commit' do
       db.delete('0')
+      sleep 0.1
       db.delete('1')
+      sleep 0.1
       expect(snapshots).to eq [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
     end
   end

--- a/spec/couchbase_lite/server_spec.rb
+++ b/spec/couchbase_lite/server_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe CouchbaseLite::Server do
   context 'blob replication' do
     let(:blob_storage) { db.blob_storage }
     let(:replica_blob_storage) { db_replica.blob_storage }
-    let(:megabyte) { 1024 * 1024 }
-    let(:contents) { Random.new.bytes(5 * megabyte) }
+    let(:blob_size) { 1024 * 512 }
+    let(:contents) { Random.new.bytes(5 * blob_size) }
     let(:blob_ref) { blob_storage.store(contents) }
 
     before do

--- a/spec/couchbase_lite/server_spec.rb
+++ b/spec/couchbase_lite/server_spec.rb
@@ -85,12 +85,6 @@ RSpec.describe CouchbaseLite::Server do
             expect(conflicting_revs[0][:body]).to eq(replica_rev)
             expect(conflicting_revs[1][:body]).to eq(master_rev)
 
-            db_replica.resolve_conflicts(doc, conflicting_revs.map { |r| r[:rev] }, body: { answer: 'Both.' })
-            expect(doc).to_not be_conflicted
-
-            reloaded_doc = db_replica.get('42')
-            expect(reloaded_doc).to_not be_conflicted
-            expect(reloaded_doc.body).to eq(answer: 'Both.')
             replicator.stop
           }.
           always { EM.stop }


### PR DESCRIPTION
Ok, this should finally enable live conflict monitoring in Lantern. It better work :)

Note: I can see how I’m going to regret switching to Thread-based default async method (esp., in tests), but the alternative is CBLite deadlocks.